### PR TITLE
close #57 by adding freesound.org API descriptions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -620,6 +620,11 @@ export default class FreeSound {
   }
 
   /**
+   * Set the credentials supplied by https://freesound.org/apiv2/apply for API
+   * call authentication. See
+   * https://freesound.org/docs/api/authentication.html?highlight=secret#token-authentication
+   * for more information.
+   *
    * @param id your client ID, obtainable at https://freesound.org/apiv2/apply
    * @param secret your client secret, obtainable at https://freesound.org/apiv2/apply
    *

--- a/index.ts
+++ b/index.ts
@@ -771,16 +771,11 @@ export default class FreeSound {
   }
 
   /**
-   * Retrieve a list of audio files uploaded by
-   * the Freesound user logged in using OAuth2 that
-   * do not have a description, or have not been
-   * processed or moderated. In Freesound, sounds
-   * need descriptions after their upload. Then,
-   * sounds are automatically processed, and,
-   * finally, a team of human moderators either
-   * accepts or rejects the upload. This method keeps
-   * track of the status of these uploads and
-   * requires OAuth2 authentication. See
+   * Retrieve a list of audio files uploaded by he Freesound user logged in using
+   * OAuth2 are not described, processed or moderated. In Freesound, sounds need
+   * descriptions after their upload. Then, sounds are automatically processed, and,
+   * finally, a team of human moderators either accepts or rejects the upload. This method
+   * keeps track of the status of these uploads and requires OAuth2 authentication. See
    * https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required
    * for more information.
    *

--- a/index.ts
+++ b/index.ts
@@ -609,6 +609,7 @@ export default class FreeSound {
    * downloading sounds.
    *
    * This method can set both kinds of tokens
+   *
    * ```typescript
    * await freeSound.setToken('your-api-key', 'oauth');
    * ```
@@ -619,14 +620,15 @@ export default class FreeSound {
   }
 
   /**
+   * @param id your client ID, obtainable at https://freesound.org/apiv2/apply
+   * @param secret your client secret, obtainable at https://freesound.org/apiv2/apply
+   *
    * ```typescript
    * await freeSound.setClientSecrets(
    *   "your-client-id",
    *   "your-secret-key"
    * );
    * ```
-   * @param id your client ID, obtainable at https://freesound.org/apiv2/apply
-   * @param secret your client secret, obtainable at https://freesound.org/apiv2/apply
    */
   setClientSecrets(id: string, secret: string) {
     this.clientId = id;
@@ -636,6 +638,7 @@ export default class FreeSound {
   /**
    * This method allows you to get a new token using a refresh token or an auth
    * token
+   *
    * ```typescript
    * await freeSound.postAccessCode('your-temporary-code-from-login');
    * ```
@@ -660,6 +663,7 @@ export default class FreeSound {
    * Search sounds in Freesound by matching their tags and other kinds of metadata. See
    * https://freesound.org/docs/api/resources_apiv2.html#sound-text-search for more
    * information.
+   *
    * ```typescript
    * await freeSound.textSearch('violoncello', {
    *   page: 1,
@@ -681,6 +685,7 @@ export default class FreeSound {
    * Search sounds in Freesound based on their content descriptors. See
    * https://freesound.org/docs/api/resources_apiv2.html#content-search
    * for more information.
+   *
    * ```typescript
    * const result = await freeSound.contentSearch({
    *   target: 'lowlevel.pitch.mean:220',
@@ -702,6 +707,7 @@ export default class FreeSound {
    * Search sounds in Freesound based on their tags, metadata and content-based descriptiors via
    * a combination of text search and content search. See
    * https://freesound.org/docs/api/resources_apiv2.html#combined-search for more information.
+   *
    * ```typescript
    * const soundCollectionResults = await freeSound.combinedSearch(
    *   filter: 'tag:scale',
@@ -716,7 +722,7 @@ export default class FreeSound {
     return this.search(options, this.uris.combinedSearch);
   }
 
-   /**
+  /**
    * Upload an audio file into Freesound and optionally describe it.
    * If there is no file description, only the audio file will upload, and
    * the user will need to add a description later using
@@ -726,6 +732,7 @@ export default class FreeSound {
    * obtainable through the getPendingSounds() method. See
    * https://freesound.org/docs/api/resources_apiv2.html#upload-sound-oauth2-required
    * for more information. This method requires OAuth2 authentication.
+   *
    * @param audiofile the audio file to upload
    * @param filename the name of the audio file to upload
    * @param description the description of the audio file to upload
@@ -749,6 +756,7 @@ export default class FreeSound {
    * the getPendingSounds() method. This method requires OAuth2 authentication. See
    * https://freesound.org/docs/api/resources_apiv2.html#describe-sound-oauth2-required
    * for more information.
+   *
    * @param description a description for an uploaded sound
    */
   describe(description: { description: string }) {
@@ -770,6 +778,7 @@ export default class FreeSound {
    * requires OAuth2 authentication. See
    * https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required
    * for more information.
+   *
    * ```typescript
    * const result = await freeSound.getPendingSounds()
    * ```
@@ -782,6 +791,7 @@ export default class FreeSound {
   /**
    * Return basic information about the user that is logged in via OAuth2.
    * This application can use it to identify which Freesound user has logged in.
+   *
    * ```typescript
    * const result = await freeSound.me();
    * ```
@@ -816,12 +826,14 @@ export default class FreeSound {
    * Retrieve information about a particular Freesound user. See
    * https://freesound.org/docs/api/resources_apiv2.html#user-instance
    * for more information.
+   *
+   * @param username the username of the Freesound user
+   * @returns information about a particular Freesound user
+   *
    * ```typescript
    * // Get information about the user https://freesound.org/people/MTG/.
    * const user = await freeSound.getUser('MTG');
    * ```
-   * @param username the username of the Freesound user
-   * @returns information about a particular Freesound user
    */
   getUser(username: string): Promise<User> {
     return this.makeRequest<RawUser>(this.makeUri(this.uris.user, [username])).then(e =>
@@ -832,13 +844,15 @@ export default class FreeSound {
   /**
    * Retrieve the list of sounds included in a pack. See
    * https://freesound.org/docs/api/resources_apiv2.html#pack-sounds for more information.
+   *
+   * @param packId the identification number of the pack to fetch
+   * @returns a list of sounds included in the pack that has packId as its identification number
+   *
    * ```typescript
    * // Fetch the pack
    * // https://freesound.org/people/vroomvro0om/packs/21143/.
    * const packObj = await freeSound.getPack(21143);
    * ```
-   * @param packId the identification number of the pack to fetch
-   * @returns a list of sounds included in the pack that has packId as its identification number
    */
   async getPack(packId: string | number, options = {}): Promise<Pack> {
     const pack = await this.makeRequest<RawPack>(this.makeUri(this.uris.pack, [packId]), 'GET', options);
@@ -849,13 +863,15 @@ export default class FreeSound {
    * Retrieve detailed information about a sound. See
    * https://freesound.org/docs/api/resources_apiv2.html#sound-resources
    * for more information.
+   *
+   * @param soundId the identification number of the sound
+   * @returns detailed information about a sound
+   *
    * ```typescript
    * // Fetch the sound
    * // https://freesound.org/people/vroomvro0om/sounds/376626/.
    * const fetchedSound = await freeSound.getSound(376626);
    * ```
-   * @param soundId the identification number of the sound
-   * @returns detailed information about a sound
    */
   async getSound(soundId: string | number): Promise<Sound> {
     const sound = await this.makeRequest<Sound>(this.makeUri(this.uris.sound, [soundId]));

--- a/index.ts
+++ b/index.ts
@@ -641,8 +641,9 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows searching sounds in Freesound by matching their tags and other
-   * kinds of metadata. See https://freesound.org/docs/api/resources_apiv2.html#sound-text-search.
+   * Search sounds in Freesound by matching their tags and other kinds of metadata. See
+   * https://freesound.org/docs/api/resources_apiv2.html#sound-text-search for more
+   * information.
    */
   textSearch(query: string, opts: TextSearchOpts = {}) {
     const options = { ...opts };
@@ -653,8 +654,9 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows searching sounds in Freesound based on their content
-   * descriptors. See https://freesound.org/docs/api/resources_apiv2.html#content-search.
+   * Search sounds in Freesound based on their content descriptors. See
+   * https://freesound.org/docs/api/resources_apiv2.html#content-search
+   * for more information.
    */
   contentSearch(options: SearchOpts): Promise<SoundCollection> {
     if (
@@ -668,9 +670,9 @@ export default class FreeSound {
   }
 
   /**
-   * This method is a combination of text search and content search. It allows searching
-   * sounds in Freesound based on their tags, metadata and content-based descriptiors.
-   * See https://freesound.org/docs/api/resources_apiv2.html#combined-search.
+   * Search sounds in Freesound based on their tags, metadata and content-based descriptiors via
+   * a combination of text search and content search. See
+   * https://freesound.org/docs/api/resources_apiv2.html#combined-search for more information.
    */
   combinedSearch(options: SearchOpts) {
     if (!(options.target || options.query || options.descriptors_filter || options.target || options.filter)) {
@@ -680,13 +682,15 @@ export default class FreeSound {
   }
 
    /**
-   * This method allows uploading an audio file into Freesound and optionally describing it.
-   * If there is no file description, only the audio file will upload and a description will be needed later using
-   * the describe(description: { description: string }) method.
-   * If the file description is present, the uploaded file will be ready for the processing and moderation stage.
-   * A list of uploading files pending a description, processing or moderation is obtainable through the
-   * getPendingSounds() method. See https://freesound.org/docs/api/resources_apiv2.html#upload-sound-oauth2-required.
-   * This method requires OAuth2 authentication.
+   * Upload an audio file into Freesound and optionally describe it.
+   * If there is no file description, only the audio file will upload, and
+   * the user will need to add a description later using
+   * the describe(description: { description: string }) method. If the file description
+   * is present, the uploaded file will be ready for the processing and moderation stage.
+   * A list of uploaded files pending a description, processing or moderation is
+   * obtainable through the getPendingSounds() method. See
+   * https://freesound.org/docs/api/resources_apiv2.html#upload-sound-oauth2-required
+   * for more information. This method requires OAuth2 authentication.
    * @param audiofile the audio file to upload
    * @param filename the name of the audio file to upload
    * @param description the description of the audio file to upload
@@ -702,12 +706,14 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows describing a previously uploaded file that does not have a description.
-   * Note: after a sound receives a description, the team of Freesound moderators still needs to process and
-   * moderate it, so it may not yet appear in Freesound. A list of sounds uploaded and described by the user,
-   * but still pending processing and moderation, is viewable with the getPendingSounds() method.
-   * This method requires OAuth2 authentication.
-   * See https://freesound.org/docs/api/resources_apiv2.html#describe-sound-oauth2-required.
+   * Describe a previously uploaded file that does not have a description.
+   * Note: after a sound receives a description, the team of Freesound moderators
+   * still needs to process and moderate it, so it may not yet appear in Freesound.
+   * A list of sounds uploaded and described by the user, but still
+   * pending processing and moderation, is viewable with
+   * the getPendingSounds() method. This method requires OAuth2 authentication. See
+   * https://freesound.org/docs/api/resources_apiv2.html#describe-sound-oauth2-required
+   * for more information.
    * @param description a description for an uploaded sound
    */
   describe(description: { description: string }) {
@@ -717,12 +723,18 @@ export default class FreeSound {
   }
 
   /**
-   * This method retrieves a list of audio files uploaded by the Freesound user logged in using OAuth2 that
-   * do not have a description, or have not been processed or moderated. In Freesound, sounds need descriptions
-   * after their upload. Then, sounds are automatically processed, and, finally, a team of human moderators
-   * either accepts or rejects the upload. This method keeps track of the status of these uploads.
-   * This method requires OAuth2 authentication.
-   * See https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required.
+   * Retrieve a list of audio files uploaded by
+   * the Freesound user logged in using OAuth2 that
+   * do not have a description, or have not been
+   * processed or moderated. In Freesound, sounds
+   * need descriptions after their upload. Then,
+   * sounds are automatically processed, and,
+   * finally, a team of human moderators either
+   * accepts or rejects the upload. This method keeps
+   * track of the status of these uploads and
+   * requires OAuth2 authentication. See
+   * https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required
+   * for more information.
    */
   getPendingSounds() {
     this.checkOauth();
@@ -730,7 +742,7 @@ export default class FreeSound {
   }
 
   /**
-   * This method returns basic information about the user that is logged in via OAuth2.
+   * Return basic information about the user that is logged in via OAuth2.
    * This application can use it to identify which Freesound user has logged in.
    */
   me() {
@@ -753,9 +765,9 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows the retrieval of information about a particular Freesound user.
-   * See https://freesound.org/docs/api/resources_apiv2.html#user-instance.
-   * @param username the username of the Freesound user whose information you want
+   * Retrieve information about a particular Freesound user. See
+   * https://freesound.org/docs/api/resources_apiv2.html#user-instance for more information.
+   * @param username the username of the Freesound user
    * @returns information about a particular Freesound user
    */
   getUser(username: string): Promise<User> {
@@ -765,10 +777,10 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows the retrieval of the list of sounds included in a pack.
-   * See https://freesound.org/docs/api/resources_apiv2.html#pack-sounds.
-   * @param packId The identification number of the pack to fetch
-   * @returns a list of sounds included in the pack whose ID is packId
+   * Retrieve the list of sounds included in a pack. See
+   * https://freesound.org/docs/api/resources_apiv2.html#pack-sounds for more information.
+   * @param packId the identification number of the pack to fetch
+   * @returns a list of sounds included in the pack that has packId as its identification number
    */
   async getPack(packId: string | number, options = {}): Promise<Pack> {
     const pack = await this.makeRequest<RawPack>(this.makeUri(this.uris.pack, [packId]), 'GET', options);
@@ -776,9 +788,9 @@ export default class FreeSound {
   }
 
   /**
-   * This method allows the retrieval of detailed information about a sound.
-   * See https://freesound.org/docs/api/resources_apiv2.html#sound-resources.
-   * @param soundId the identification number of the sound you want detailed information about
+   * Retrieve detailed information about a sound. See
+   * https://freesound.org/docs/api/resources_apiv2.html#sound-resources for more information.
+   * @param soundId the identification number of the sound
    * @returns detailed information about a sound
    */
   async getSound(soundId: string | number): Promise<Sound> {

--- a/index.ts
+++ b/index.ts
@@ -640,6 +640,10 @@ export default class FreeSound {
     return this.makeRequest<AccessTokenResponse>(postUrl, 'POST', data);
   }
 
+  /**
+   * This method allows searching sounds in Freesound by matching their tags and other
+   * kinds of metadata. See https://freesound.org/docs/api/resources_apiv2.html#sound-text-search.
+   */
   textSearch(query: string, opts: TextSearchOpts = {}) {
     const options = { ...opts };
     options.query = query || ' ';
@@ -648,6 +652,10 @@ export default class FreeSound {
     );
   }
 
+  /**
+   * This method allows searching sounds in Freesound based on their content
+   * descriptors. See https://freesound.org/docs/api/resources_apiv2.html#content-search.
+   */
   contentSearch(options: SearchOpts): Promise<SoundCollection> {
     if (
       !(options.target || options.analysis_file || options.descriptors_filter)
@@ -659,6 +667,11 @@ export default class FreeSound {
     );
   }
 
+  /**
+   * This method is a combination of text search and content search. It allows searching
+   * sounds in Freesound based on their tags, metadata and content-based descriptiors.
+   * See https://freesound.org/docs/api/resources_apiv2.html#combined-search.
+   */
   combinedSearch(options: SearchOpts) {
     if (!(options.target || options.query || options.descriptors_filter || options.target || options.filter)) {
       throw new Error('Missing target, query, descriptors_filter, target, filter, or analysis_file');
@@ -666,6 +679,18 @@ export default class FreeSound {
     return this.search(options, this.uris.combinedSearch);
   }
 
+   /**
+   * This method allows uploading an audio file into Freesound and optionally describing it.
+   * If there is no file description, only the audio file will upload and a description will be needed later using
+   * the describe(description: { description: string }) method.
+   * If the file description is present, the uploaded file will be ready for the processing and moderation stage.
+   * A list of uploading files pending a description, processing or moderation is obtainable through the
+   * getPendingSounds() method. See https://freesound.org/docs/api/resources_apiv2.html#upload-sound-oauth2-required.
+   * This method requires OAuth2 authentication.
+   * @param audiofile the audio file to upload
+   * @param filename the name of the audio file to upload
+   * @param description the description of the audio file to upload
+   */
   upload(audiofile: string, filename: string, description: { description: string }) {
     this.checkOauth();
     let formData = new FormData();
@@ -676,18 +701,38 @@ export default class FreeSound {
     return this.makeRequest(this.makeUri(this.uris.upload), 'POST', formData);
   }
 
+  /**
+   * This method allows describing a previously uploaded file that does not have a description.
+   * Note: after a sound receives a description, the team of Freesound moderators still needs to process and
+   * moderate it, so it may not yet appear in Freesound. A list of sounds uploaded and described by the user,
+   * but still pending processing and moderation, is viewable with the getPendingSounds() method.
+   * This method requires OAuth2 authentication.
+   * See https://freesound.org/docs/api/resources_apiv2.html#describe-sound-oauth2-required.
+   * @param description a description for an uploaded sound
+   */
   describe(description: { description: string }) {
     this.checkOauth();
     const formData = this.makeFormData(description);
     return this.makeRequest(this.makeUri(this.uris.upload), 'POST', formData);
   }
 
+  /**
+   * This method retrieves a list of audio files uploaded by the Freesound user logged in using OAuth2 that
+   * do not have a description, or have not been processed or moderated. In Freesound, sounds need descriptions
+   * after their upload. Then, sounds are automatically processed, and, finally, a team of human moderators
+   * either accepts or rejects the upload. This method keeps track of the status of these uploads.
+   * This method requires OAuth2 authentication.
+   * See https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required.
+   */
   getPendingSounds() {
     this.checkOauth();
     return this.makeRequest(this.makeUri(this.uris.pending));
   }
 
-  // user resources
+  /**
+   * This method returns basic information about the user that is logged in via OAuth2.
+   * This application can use it to identify which Freesound user has logged in.
+   */
   me() {
     this.checkOauth();
     return this.makeRequest(this.makeUri(this.uris.me));
@@ -707,17 +752,35 @@ export default class FreeSound {
     return logoutUrl;
   }
 
+  /**
+   * This method allows the retrieval of information about a particular Freesound user.
+   * See https://freesound.org/docs/api/resources_apiv2.html#user-instance.
+   * @param username the username of the Freesound user whose information you want
+   * @returns information about a particular Freesound user
+   */
   getUser(username: string): Promise<User> {
     return this.makeRequest<RawUser>(this.makeUri(this.uris.user, [username])).then(e =>
       this.UserObject(e)
     );
   }
 
+  /**
+   * This method allows the retrieval of the list of sounds included in a pack.
+   * See https://freesound.org/docs/api/resources_apiv2.html#pack-sounds.
+   * @param packId The identification number of the pack to fetch
+   * @returns a list of sounds included in the pack whose ID is packId
+   */
   async getPack(packId: string | number, options = {}): Promise<Pack> {
     const pack = await this.makeRequest<RawPack>(this.makeUri(this.uris.pack, [packId]), 'GET', options);
     return this.PackObject(pack);
   }
 
+  /**
+   * This method allows the retrieval of detailed information about a sound.
+   * See https://freesound.org/docs/api/resources_apiv2.html#sound-resources.
+   * @param soundId the identification number of the sound you want detailed information about
+   * @returns detailed information about a sound
+   */
   async getSound(soundId: string | number): Promise<Sound> {
     const sound = await this.makeRequest<Sound>(this.makeUri(this.uris.sound, [soundId]));
     return this.SoundObject(sound);

--- a/index.ts
+++ b/index.ts
@@ -609,12 +609,25 @@ export default class FreeSound {
    * downloading sounds.
    *
    * This method can set both kinds of tokens
+   * ```typescript
+   * await freeSound.setToken('your-api-key', 'oauth');
+   * ```
    */
   setToken(token: string, type?: "oauth"): string {
     this.authHeader = `${type === 'oauth' ? 'Bearer' : 'Token'} ${token}`;
     return this.authHeader;
   }
 
+  /**
+   * ```typescript
+   * await freeSound.setClientSecrets(
+   *   "your-client-id",
+   *   "your-secret-key"
+   * );
+   * ```
+   * @param id your client ID, obtainable at https://freesound.org/apiv2/apply
+   * @param secret your client secret, obtainable at https://freesound.org/apiv2/apply
+   */
   setClientSecrets(id: string, secret: string) {
     this.clientId = id;
     this.clientSecret = secret;
@@ -623,6 +636,9 @@ export default class FreeSound {
   /**
    * This method allows you to get a new token using a refresh token or an auth
    * token
+   * ```typescript
+   * await freeSound.postAccessCode('your-temporary-code-from-login');
+   * ```
    */
   postAccessCode(token: string, type: 'refresh' | 'auth' = 'auth'): Promise<AccessTokenResponse> {
     const postUrl = `${this.uris.base}/oauth2/access_token/`;
@@ -644,6 +660,14 @@ export default class FreeSound {
    * Search sounds in Freesound by matching their tags and other kinds of metadata. See
    * https://freesound.org/docs/api/resources_apiv2.html#sound-text-search for more
    * information.
+   * ```typescript
+   * await freeSound.textSearch('violoncello', {
+   *   page: 1,
+   *   filter: 'tag:tenuto duration:[1.0 TO 15.0]',
+   *   sort: 'rating_desc',
+   *   fields: 'id,name,url'
+   * });
+   * ```
    */
   textSearch(query: string, opts: TextSearchOpts = {}) {
     const options = { ...opts };
@@ -657,6 +681,11 @@ export default class FreeSound {
    * Search sounds in Freesound based on their content descriptors. See
    * https://freesound.org/docs/api/resources_apiv2.html#content-search
    * for more information.
+   * ```typescript
+   * const result = await freeSound.contentSearch({
+   *   target: 'lowlevel.pitch.mean:220',
+   * });
+   * ```
    */
   contentSearch(options: SearchOpts): Promise<SoundCollection> {
     if (
@@ -673,6 +702,12 @@ export default class FreeSound {
    * Search sounds in Freesound based on their tags, metadata and content-based descriptiors via
    * a combination of text search and content search. See
    * https://freesound.org/docs/api/resources_apiv2.html#combined-search for more information.
+   * ```typescript
+   * const soundCollectionResults = await freeSound.combinedSearch(
+   *   filter: 'tag:scale',
+   *   target: 'rhythm.bpm:120',
+   * );
+   * ```
    */
   combinedSearch(options: SearchOpts) {
     if (!(options.target || options.query || options.descriptors_filter || options.target || options.filter)) {
@@ -735,6 +770,9 @@ export default class FreeSound {
    * requires OAuth2 authentication. See
    * https://freesound.org/docs/api/resources_apiv2.html#pending-uploads-oauth2-required
    * for more information.
+   * ```typescript
+   * const result = await freeSound.getPendingSounds()
+   * ```
    */
   getPendingSounds() {
     this.checkOauth();
@@ -744,12 +782,22 @@ export default class FreeSound {
   /**
    * Return basic information about the user that is logged in via OAuth2.
    * This application can use it to identify which Freesound user has logged in.
+   * ```typescript
+   * const result = await freeSound.me();
+   * ```
    */
   me() {
     this.checkOauth();
     return this.makeRequest(this.makeUri(this.uris.me));
   }
 
+  /**
+   * ```typescript
+   * const navigateToLogin = () => {
+   *   window.location.replace(freeSound.getLoginURL());
+   * };
+   * ```
+   */
   getLoginURL(): string {
     if (!this.clientId) throw new Error('client_id was not set');
     let loginUrl = this.makeUri(this.uris.authorize);
@@ -766,7 +814,12 @@ export default class FreeSound {
 
   /**
    * Retrieve information about a particular Freesound user. See
-   * https://freesound.org/docs/api/resources_apiv2.html#user-instance for more information.
+   * https://freesound.org/docs/api/resources_apiv2.html#user-instance
+   * for more information.
+   * ```typescript
+   * // Get information about the user https://freesound.org/people/MTG/.
+   * const user = await freeSound.getUser('MTG');
+   * ```
    * @param username the username of the Freesound user
    * @returns information about a particular Freesound user
    */
@@ -779,6 +832,11 @@ export default class FreeSound {
   /**
    * Retrieve the list of sounds included in a pack. See
    * https://freesound.org/docs/api/resources_apiv2.html#pack-sounds for more information.
+   * ```typescript
+   * // Fetch the pack
+   * // https://freesound.org/people/vroomvro0om/packs/21143/.
+   * const packObj = await freeSound.getPack(21143);
+   * ```
    * @param packId the identification number of the pack to fetch
    * @returns a list of sounds included in the pack that has packId as its identification number
    */
@@ -789,7 +847,13 @@ export default class FreeSound {
 
   /**
    * Retrieve detailed information about a sound. See
-   * https://freesound.org/docs/api/resources_apiv2.html#sound-resources for more information.
+   * https://freesound.org/docs/api/resources_apiv2.html#sound-resources
+   * for more information.
+   * ```typescript
+   * // Fetch the sound
+   * // https://freesound.org/people/vroomvro0om/sounds/376626/.
+   * const fetchedSound = await freeSound.getSound(376626);
+   * ```
    * @param soundId the identification number of the sound
    * @returns detailed information about a sound
    */

--- a/index.ts
+++ b/index.ts
@@ -802,6 +802,10 @@ export default class FreeSound {
   }
 
   /**
+   * Navigate to Freesound for user login.
+   *
+   * @returns a url where the user can login
+   *
    * ```typescript
    * const navigateToLogin = () => {
    *   window.location.replace(freeSound.getLoginURL());


### PR DESCRIPTION
# Pull Request
This pull request closes #57 if we merge it.

I added descriptions from the Freesound API and left a sort of "trail of breadcrumbs" by linking to the Freesound API in the added descriptions in case people wanted more information. While I was at it, I filled in some of the descriptions for parameters and return values, although I wasn't exhaustive; I just filled in the parameter and return values that were clear to me.


# Testing
I noticed one of the tests didn't pass locally, even with a valid `CLIENT_ID` and `CLIENT_SECRET` in the `.env` file.

The test that failed is `✕ should perform combined search (18443 ms)`.

```
  ● API › Search › should perform combined search

    expect(received).toMatchSnapshot()

    Snapshot name: `API Search should perform combined search 1`

    - Snapshot  - 1
    + Received  + 1

      Object {
    -   "more": "http://freesound.org/apiv2/search/combined/?&query=&filter=tag:loop&target=rhythm.bpm:120&cs_lcvidp=41",
    +   "more": "http://freesound.org/apiv2/search/combined/?&query=&filter=tag:loop&target=rhythm.bpm:120&cs_lcvidp=43",
      }
```

Updating that snapshot might be necessary, although I'm not sure how to do that off the top of my head.