### PR TITLE
docs: split code block for easier copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ A freesound v2 client that works in node and the browser
 ## Installation
 
 ```bash
-# npm
 npm install freesound-client
-# yarn
+```
+
+```bash
 yarn add freesound-client
 ```
 


### PR DESCRIPTION
Copying the code block without this change on GitHub copies both the `npm` and `yarn` installation instructions.

It'll be easier for readers if there are two separate code blocks, so that if they click the copy button in the browser, they just get the command they want.

https://user-images.githubusercontent.com/43425812/190946890-b05b6b27-ee78-4dc3-ac03-ad5a18ccb9e6.mp4